### PR TITLE
Update Cargo.toml: set fix dependencies for egui_mobius_*

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ eframe = "0.31.1" # For egui-based applications
 egui = "0.31.1"
 egui_dock = "0.16.0"
 egui_extras = { version = "0.31.1", features = ["image"] } # For image loading and other utilities
-egui_mobius = "0.3.0-alpha.25" # Core mobius framework
-egui_mobius_widgets = "0.3.0-alpha.25" # For egui widgets
-egui_mobius_reactive = "0.3.0-alpha.25" # For reactive state management
+egui_mobius = "=0.3.0-alpha.25" # Core mobius framework
+egui_mobius_widgets = "=0.3.0-alpha.25" # For egui widgets
+egui_mobius_reactive = "=0.3.0-alpha.25" # For reactive state management
 chrono = { version = "0.4", features = ["serde"] } # For timestamps
 image = "0.24" # For image loading
 once_cell = "1.19" # For static initialization


### PR DESCRIPTION
set fix dependencies for egui_mobius_* otherwise cargo is like: "LeT mE PulL tHe alpha.32 VeRsIon FoR yOu" 

This pulls egui 0.32 which breaks the demo